### PR TITLE
MultiItemVariationStore variationRegionListOffset should be 4 bytes

### DIFF
--- a/VARC.md
+++ b/VARC.md
@@ -152,7 +152,7 @@ for each region.
 struct MultiItemVariationStore
 {
   uint16 format; // Set to 1
-  LOffsetTo<SparseVariationRegionList> variationRegionListOffset;
+  Offset32To<SparseVariationRegionList> variationRegionListOffset;
   uint16 itemVariationDataCount;
   Offset32To<MultiItemVariationData> itemVariationDataOffsets[itemVariationDataCount];
 };


### PR DESCRIPTION
[FontTools](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3451-L3457) and [HarfBuzz](https://github.com/harfbuzz/harfbuzz/blob/7be12b33e3f07067c159d8f516eb31df58c75876/src/hb-ot-layout-common.hh#L3517-L3520C3) appear to agree this is a 4 byte offset.